### PR TITLE
Downgraded star printer SDK to 1.0.1 

### DIFF
--- a/buildSrc/src/main/kotlin/Configs.kt
+++ b/buildSrc/src/main/kotlin/Configs.kt
@@ -4,7 +4,7 @@ object Configs {
     const val APPLICATION_ID = "de.tillhub.printengine"
     const val COMPILE_SDK = 34
     const val MIN_SDK = 23
-    const val VERSION_CODE = "2.0.2"
+    const val VERSION_CODE = "2.0.3"
     val JAVA_VERSION = JavaVersion.VERSION_17
     val JVM_TARGET = JAVA_VERSION.toString()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,10 @@ runner = "1.6.2"
 rules = "1.6.1"
 truth = "1.6.0"
 
-starPrinter = "1.8.0"
+# Downgraded to avoid runtime crash caused by instrumentation
+# when enableAndroidTestCoverage = true
+# See: https://github.com/star-micronics/StarXpand-SDK-Android/issues/18
+starPrinter = "1.0.1"
 
 
 lifecycle = "2.7.0"


### PR DESCRIPTION
# Downgraded to 1.0.1 to avoid runtime crash caused by instrumentation when enableAndroidTestCoverage = true
# See: https://github.com/star-micronics/StarXpand-SDK-Android/issues/18