### PR TITLE
[UNTIL-19364] Fix Maven Central publishing setup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.compose.compiler).apply(false)
     alias(libs.plugins.compose).apply(false)
     alias(libs.plugins.spotless).apply(false)
+    alias(libs.plugins.maven.publish).apply(false)
 }
 subprojects {
     apply(plugin = "com.diffplug.spotless")

--- a/print-engine/build.gradle.kts
+++ b/print-engine/build.gradle.kts
@@ -19,6 +19,8 @@ kotlin {
             jvmTarget.set(JvmTarget.JVM_17)
         }
 
+        publishLibraryVariants("release")
+
         dependencies {
             // Core Dependencies
             implementation(libs.androidx.core)

--- a/print-plugins/epson/build.gradle.kts
+++ b/print-plugins/epson/build.gradle.kts
@@ -18,6 +18,8 @@ kotlin {
             jvmTarget.set(JvmTarget.JVM_17)
         }
 
+        publishLibraryVariants("release")
+
         dependencies {
             // Core Dependencies
             implementation(libs.androidx.core)

--- a/print-plugins/pax/build.gradle.kts
+++ b/print-plugins/pax/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -71,6 +72,13 @@ dependencies {
 }
 
 mavenPublishing {
+    configure(
+        AndroidSingleVariantLibrary(
+            sourcesJar = true,
+            publishJavadocJar = false,
+        ),
+    )
+
     // Define coordinates for the published artifact
     coordinates(
         groupId = "io.github.tillhub",

--- a/print-plugins/star/build.gradle.kts
+++ b/print-plugins/star/build.gradle.kts
@@ -18,6 +18,8 @@ kotlin {
             jvmTarget.set(JvmTarget.JVM_17)
         }
 
+        publishLibraryVariants("release")
+
         dependencies {
             // Core Dependencies
             implementation(libs.androidx.core)
@@ -124,7 +126,7 @@ mavenPublishing {
 
     // Configure POM metadata for the published artifact
     pom {
-        name.set("Start Print Engine plugin")
+        name.set("Star Print Engine plugin")
         description.set("Kotlin MultiPlatform Library printer implementation for Star printers")
         inceptionYear.set("2025")
         url.set("https://github.com/tillhub/print-engine")

--- a/print-plugins/verifone/build.gradle.kts
+++ b/print-plugins/verifone/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -69,6 +70,13 @@ dependencies {
 }
 
 mavenPublishing {
+    configure(
+        AndroidSingleVariantLibrary(
+            sourcesJar = true,
+            publishJavadocJar = false,
+        ),
+    )
+
     // Define coordinates for the published artifact
     coordinates(
         groupId = "io.github.tillhub",
@@ -81,7 +89,7 @@ mavenPublishing {
     // Configure POM metadata for the published artifact
     pom {
         name.set("Verifone Print Engine plugin")
-        description.set("Kotlin MultiPlatform Library printer implementation for Pax devices")
+        description.set("Kotlin MultiPlatform Library printer implementation for Verifone devices")
         inceptionYear.set("2025")
         url.set("https://github.com/tillhub/print-engine")
 


### PR DESCRIPTION
## Summary
- Add `maven-publish` plugin declaration to root `build.gradle.kts`
- Add `publishLibraryVariants("release")` to KMM modules (print-engine, star, epson)
- Add `AndroidSingleVariantLibrary` configuration to Android-only modules (pax, verifone)

## Why
The develop branch has publishing gaps compared to payment-engine, scan-engine, and input-engine. Without these fixes, merging to master will break the Maven Central release workflow.

## Test plan
- [x] `spotlessCheck` passes
- [x] `testDebug` passes for all modules
- [x] POM files generate correctly for all 5 artifacts
- [x] `publishAndReleaseToMavenCentral` task registered for all 5 modules

## Jira
[UNTIL-19364](https://unz.atlassian.net/browse/UNTIL-19364)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[UNTIL-19364]: https://unz.atlassian.net/browse/UNTIL-19364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ