### PR TITLE
Fix release workflow: remove non-existent task exclusion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,4 +50,4 @@ jobs:
 
       - name: Publish To Maven Central
         run: |
-          ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache -x javaDocReleaseGeneration
+          ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache


### PR DESCRIPTION
## Summary
- Remove `-x javaDocReleaseGeneration` from the Maven Central publish command in `release.yml`
- This task does not exist in the project, and Gradle 8.13 fails when trying to exclude a non-existent task
- Fixes the build failure: https://github.com/tillhub/print-engine/actions/runs/22999989869/job/66781838692

## Test plan
- [ ] Merge and verify the release workflow succeeds on the next push to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)